### PR TITLE
Add missing Box component links

### DIFF
--- a/src/Box.jsx
+++ b/src/Box.jsx
@@ -5,6 +5,8 @@ import FontAwesome from 'react-fontawesome';
 import BoxHeader from './BoxHeader';
 import BoxBody from './BoxBody';
 import BoxFooter from './BoxFooter';
+import BoxTitle from './BoxTitle';
+import BoxTools from './BoxTools';
 
 const propTypes = {
   style: React.PropTypes.oneOf(['default', 'primary', 'success', 'warning', 'danger']),
@@ -52,5 +54,7 @@ Box.defaultProps = defaultProps;
 Box.Header = BoxHeader;
 Box.Body = BoxBody;
 Box.Footer = BoxFooter;
+Box.Title = BoxTitle;
+Box.Tools = BoxTools;
 
 export default Box;


### PR DESCRIPTION
`BoxTitle` and `BoxTools` were not linked in `Box`, I have added them.

Now you can refer to `Box.Tools` and `Box.Title`, and all is well in the world.